### PR TITLE
Add better email validator regex pattern

### DIFF
--- a/__tests__/validator.spec.js
+++ b/__tests__/validator.spec.js
@@ -53,7 +53,7 @@ describe('validator', () => {
         });
       });
 
-      describe('when value does not match /.+@.+\..+/', () => {
+      describe('when value does not match the email regex', () => {
         it('should return false', () => {
           expect(validator.isValid('email')).toBe(false);
           expect(validator.isValid('email', null)).toBe(false);
@@ -66,6 +66,14 @@ describe('validator', () => {
           expect(validator.isValid('email', 'test@testcom')).toBe(false);
           expect(validator.isValid('email', ' test@testcom')).toBe(false);
           expect(validator.isValid('email', '..test@testcom')).toBe(false);
+          expect(validator.isValid('email', 'test@test.com @test.com')).toBe(false);
+          expect(validator.isValid('email', 'test@test@test.com')).toBe(false);
+          expect(validator.isValid('email', 'testő@test.com')).toBe(false);
+          expect(validator.isValid('email', 'test@test.com.')).toBe(false);
+          expect(validator.isValid('email', 'hans@m端ller.com')).toBe(false);
+          expect(validator.isValid('email', 'test|123@m端ller.com')).toBe(false);
+          expect(validator.isValid('email', '"  foo  bar  "@example.com')).toBe(false);
+          expect(validator.isValid('email', 'ｇｍａｉｌｇｍａｉｌｇｍａｉｌｇｍａｉｌｇｍａｉｌ@gmail.com')).toBe(false);
         });
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gandalf-validator",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Determines who shall and shall not pass form validation in React",
   "main": "dist/gandalf.js",
   "scripts": {

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -23,9 +23,9 @@ const errorMessages = {
 const validatorFns = {
   required: v => v !== undefined && v !== null && v !== '',
   numeric: v => /^string|number$/.test(typeof v) && !isNaN(v),
-  // RFC 2822 compliant, minus square brackets and double quotes
-  // http://www.regular-expressions.info/email.html
-  email: v => /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/i.test(v),
+  // Borrowing the most popular JS validator's email regex pattern
+  // https://github.com/ansman/validate.js/blob/master/validate.js#L1060
+  email: v => /^(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])$/i.test(v),
   minLength: (v, l) => {
     const str = v.toString();
     return str.length >= l;


### PR DESCRIPTION
At Bench, we were experiencing several issues where people were entering emails that were rather peculiar and they ended up getting rejected by our CRM. We had two options: play whack-a-mole with validation cases, or add server-side validation up front for capturing emails. We'd prefer the former. 

Last time on email validation w/ gandalf-validator, we added the regex provided directly [from Salesforce](https://developer.salesforce.com/docs/atlas.en-us.mc-apis.meta/mc-apis/using_regular_expressions_to_validate_email_addresses.htm), but this proved to be ineffective for some cases:

`dfincher0809@msn.com.` - TLD ends with a period
`mercihercegnő5@gmail.com` - unicode character
`sherri@sunsetlocations.com @sunsetlocations.com` - Repeated hostname
`andriylutv79835@gmail@gmail.com` - Repeated hostname

To catch these, we borrowed the regex pattern from the most popular JS front-end validator library: [validate.js](https://github.com/ansman/validate.js/blob/master/validate.js#L1060). Reference the email validation test cases to see which new patterns the updated regex will allow / disallow.