### PR TITLE
Add default value for validators if none passed

### DIFF
--- a/src/validator.ts
+++ b/src/validator.ts
@@ -66,7 +66,7 @@ const getErrorMessage = (validator: string | complexValidator): string => {
   return errorMessages[validator.name];
 };
 
-const validate = (validators: Array<string | complexValidator>, value: any): validationResponse => {
+const validate = (validators: Array<string | complexValidator> = [], value: any): validationResponse => {
   const firstFailedValidator = validators.find(validator => !isValid(validator, value));
 
   return {


### PR DESCRIPTION
## Work Done

- Added a default value for validators for if none are passed. This prevents the user from having to remember to pass an empty validators array should you want to create a field with no validation. Gandalf will throw an error if validators is undefined.

![Screen Shot 2019-12-23 at 1 53 35 PM](https://user-images.githubusercontent.com/25809964/71383845-102c9980-2593-11ea-99eb-ccf78ee7ee54.png)


